### PR TITLE
Update github actions to use go 1.16

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,35 +2,30 @@ name: release
 on:
   push:
     tags:
-      - '*'
+      - "*"
 jobs:
   release:
     runs-on: ubuntu-latest
     steps:
-      -
-        name: Checkout
+      - name: Checkout
         uses: actions/checkout@v2
         with:
           fetch-depth: 0
-      -
-        name: Set up Go
+      - name: Set up Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.15
-      -
-        name: Run GoReleaser Dry-Run
+          go-version: 1.16
+      - name: Run GoReleaser Dry-Run
         uses: goreleaser/goreleaser-action@v2
         with:
           version: latest
           args: release --rm-dist --skip-validate --skip-publish --skip-sign
-      -
-        name: Import GPG key
+      - name: Import GPG key
         id: import_gpg
         uses: crazy-max/ghaction-import-gpg@v3
         with:
           gpg-private-key: ${{ secrets.PRIVATE_KEY }}
-      -
-        name: Run GoReleaser
+      - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v2
         with:
           version: latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,14 +5,14 @@ on:
     branches:
       - main
   pull_request:
-    branches: [ main ]
+    branches: [main]
 
 jobs:
   postgres:
     strategy:
       matrix:
-        dbversion: ['postgres:latest']
-        go: ['1.15']
+        dbversion: ["postgres:latest"]
+        go: ["1.16"]
         platform: [ubuntu-latest] # can not run in macOS and widnowsOS
     runs-on: ${{ matrix.platform }}
     services:
@@ -31,21 +31,20 @@ jobs:
           --health-timeout 5s
           --health-retries 5
     steps:
-    - name: Set up Go 1.x
-      uses: actions/setup-go@v2
-      with:
-        go-version: ^1.14
+      - name: Set up Go 1.x
+        uses: actions/setup-go@v2
+        with:
+          go-version: ^1.16
 
-    - name: Check out code into the Go module directory
-      uses: actions/checkout@v2
+      - name: Check out code into the Go module directory
+        uses: actions/checkout@v2
 
-    - name: Get dependencies
-      run: |
-        go get -v -t -d ./...
+      - name: Get dependencies
+        run: |
+          go get -v -t -d ./...
 
-    - name: Build
-      run: go build -v .
+      - name: Build
+        run: go build -v .
 
-    - name: Test
-      run: go test -v ./... --tags=integration
-    
+      - name: Test
+        run: go test -v ./... --tags=integration


### PR DESCRIPTION
Fix bug goreleaser skipping darwin arm64

https://goreleaser.com/deprecations/#builds-for-darwinarm64