### PR TITLE
Correct struct check for publicIpAddress and subnet (network.public_ip_addresses)

### DIFF
--- a/resources/network_public_ip_addresses.go
+++ b/resources/network_public_ip_addresses.go
@@ -242,11 +242,12 @@ func resolveNetworkPublicIPAddressSubnet(ctx context.Context, meta schema.Client
 
 	if p.PublicIPAddressPropertiesFormat == nil ||
 		p.PublicIPAddressPropertiesFormat.IPConfiguration == nil ||
-		p.PublicIPAddressPropertiesFormat.IPConfiguration.Subnet == nil {
+		p.PublicIPAddressPropertiesFormat.IPConfiguration.IPConfigurationPropertiesFormat == nil ||
+		p.PublicIPAddressPropertiesFormat.IPConfiguration.IPConfigurationPropertiesFormat.Subnet == nil {
 		return nil
 	}
 
-	out, err := json.Marshal(p.PublicIPAddressPropertiesFormat.IPConfiguration.Subnet)
+	out, err := json.Marshal(p.PublicIPAddressPropertiesFormat.IPConfiguration.IPConfigurationPropertiesFormat.Subnet)
 	if err != nil {
 		return err
 	}
@@ -259,12 +260,12 @@ func resolveNetworkPublicIPAddressPublicIPAddress(ctx context.Context, meta sche
 	}
 
 	if p.PublicIPAddressPropertiesFormat == nil ||
-		p.PublicIPAddressPropertiesFormat.IPConfiguration == nil ||
-		p.PublicIPAddressPropertiesFormat.IPConfiguration.PublicIPAddress == nil {
+		p.PublicIPAddressPropertiesFormat.IPConfiguration.IPConfigurationPropertiesFormat == nil ||
+		p.PublicIPAddressPropertiesFormat.IPConfiguration.IPConfigurationPropertiesFormat.PublicIPAddress == nil {
 		return nil
 	}
 
-	out, err := json.Marshal(p.PublicIPAddressPropertiesFormat.IPConfiguration.PublicIPAddress)
+	out, err := json.Marshal(p.PublicIPAddressPropertiesFormat.IPConfiguration.IPConfigurationPropertiesFormat.PublicIPAddress)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Took a stab at correcting the panic mentioned on Discord using the struct fields on gopkg. It appears to resolve correctly now, let me know if there's an issue.