### PR TITLE
Add `keyvault.vault` resource back

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [v0.3.9] - 2022-01-03
 ###### SDK Version: 0.6.1
 ### 🚀 Added
-* Add `keyvault.vault` resource back (this result requires a special permissions) [#111](https://github.com/cloudquery/cq-provider-azure/pull/111)
+* Add `keyvault.vault` resource back (this result requires special permissions) [#111](https://github.com/cloudquery/cq-provider-azure/pull/111)
 
 ## [v0.3.9] - 2022-01-03
 ###### SDK Version: 0.6.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [v0.3.9] - 2022-01-03
 ###### SDK Version: 0.6.1
+### 🚀 Added
+* Add `keyvault.vault` resource back (this result requires a special permissions)
+
+## [v0.3.9] - 2022-01-03
+###### SDK Version: 0.6.1
 ### :gear: Changed
 * Update to SDK Version [v0.6.1](https://github.com/cloudquery/cq-provider-sdk/blob/main/CHANGELOG.md#v061---2021-01-03)
 * Remove ad resources (deprecated and will be migrate to msgraph)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <!-- 
 ## Unreleased
-### 🚀 Added
-### :gear: Changed
-### :spider: Fixed
-### 💥 Breaking Changes
+### Added
+### Changed
+### Fixed
+### Breaking Changes
 
 -->
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [v0.3.9] - 2022-01-03
 ###### SDK Version: 0.6.1
 ### 🚀 Added
-* Add `keyvault.vault` resource back (this result requires a special permissions)
+* Add `keyvault.vault` resource back (this result requires a special permissions) [#111](https://github.com/cloudquery/cq-provider-azure/pull/111)
 
 ## [v0.3.9] - 2022-01-03
 ###### SDK Version: 0.6.1

--- a/docs/tables/azure_keyvault_vault_access_policies.md
+++ b/docs/tables/azure_keyvault_vault_access_policies.md
@@ -1,0 +1,14 @@
+
+# Table: azure_keyvault_vault_access_policies
+AccessPolicyEntry an identity that have access to the key vault All identities in the array must use the same tenant ID as the key vault's tenant ID
+## Columns
+| Name        | Type           | Description  |
+| ------------- | ------------- | -----  |
+|vault_cq_id|uuid|Unique CloudQuery ID of azure_keyvault_vaults table (FK)|
+|tenant_id|uuid|The Azure Active Directory tenant ID that should be used for authenticating requests to the key vault|
+|object_id|text|The object ID of a user, service principal or security group in the Azure Active Directory tenant for the vault The object ID must be unique for the list of access policies|
+|application_id|uuid|Application ID of the client making request on behalf of a principal|
+|permissions_keys|text[]|Permissions to keys|
+|permissions_secrets|text[]|Permissions to secrets|
+|permissions_certificates|text[]|Permissions to certificates|
+|permissions_storage|text[]|Permissions to storage accounts|

--- a/docs/tables/azure_keyvault_vault_keys.md
+++ b/docs/tables/azure_keyvault_vault_keys.md
@@ -1,0 +1,17 @@
+
+# Table: azure_keyvault_vault_keys
+KeyItem the key item containing key metadata
+## Columns
+| Name        | Type           | Description  |
+| ------------- | ------------- | -----  |
+|vault_cq_id|uuid|Unique CloudQuery ID of azure_keyvault_vaults table (FK)|
+|kid|text|Key identifier|
+|recoverable_days|integer|softDelete data retention days Value should be >=7 and <=90 when softDelete enabled, otherwise 0|
+|recovery_level|text|Reflects the deletion recovery level currently in effect for keys in the current vault If it contains 'Purgeable' the key can be permanently deleted by a privileged user; otherwise, only the system can purge the key, at the end of the retention interval Possible values include: 'Purgeable', 'RecoverablePurgeable', 'Recoverable', 'RecoverableProtectedSubscription', 'CustomizedRecoverablePurgeable', 'CustomizedRecoverable', 'CustomizedRecoverableProtectedSubscription'|
+|enabled|boolean|Determines whether the object is enabled|
+|not_before|timestamp without time zone|Not before date in UTC|
+|expires|timestamp without time zone|Expiry date in UTC|
+|created|timestamp without time zone|Creation time in UTC|
+|updated|timestamp without time zone|Last updated time in UTC|
+|tags|jsonb|Application specific metadata in the form of key-value pairs|
+|managed|boolean|True if the key's lifetime is managed by key vault If this is a key backing a certificate, then managed will be true|

--- a/docs/tables/azure_keyvault_vault_private_endpoint_connections.md
+++ b/docs/tables/azure_keyvault_vault_private_endpoint_connections.md
@@ -1,0 +1,12 @@
+
+# Table: azure_keyvault_vault_private_endpoint_connections
+Azure ketvault vault endpoint connection
+## Columns
+| Name        | Type           | Description  |
+| ------------- | ------------- | -----  |
+|vault_cq_id|uuid|Unique CloudQuery ID of azure_keyvault_vaults table (FK)|
+|private_endpoint_id|text|Full identifier of the private endpoint resource|
+|private_link_service_connection_state_status|text|Indicates whether the connection has been approved, rejected or removed by the key vault owner Possible values include: 'PrivateEndpointServiceConnectionStatusPending', 'PrivateEndpointServiceConnectionStatusApproved', 'PrivateEndpointServiceConnectionStatusRejected', 'PrivateEndpointServiceConnectionStatusDisconnected'|
+|private_link_service_connection_state_description|text|The reason for approval or rejection|
+|private_link_service_connection_state_action_required|text|A message indicating if changes on the service provider require any updates on the consumer|
+|provisioning_state|text|Provisioning state of the private endpoint connection Possible values include: 'Succeeded', 'Creating', 'Updating', 'Deleting', 'Failed', 'Disconnected'|

--- a/docs/tables/azure_keyvault_vault_secrets.md
+++ b/docs/tables/azure_keyvault_vault_secrets.md
@@ -1,0 +1,18 @@
+
+# Table: azure_keyvault_vault_secrets
+SecretItem the secret item containing secret metadata
+## Columns
+| Name        | Type           | Description  |
+| ------------- | ------------- | -----  |
+|vault_cq_id|uuid|Unique CloudQuery ID of azure_keyvault_vaults table (FK)|
+|id|text|Secret identifier|
+|recoverable_days|integer|softDelete data retention days Value should be >=7 and <=90 when softDelete enabled, otherwise 0|
+|recovery_level|text|Reflects the deletion recovery level currently in effect for secrets in the current vault If it contains 'Purgeable', the secret can be permanently deleted by a privileged user; otherwise, only the system can purge the secret, at the end of the retention interval Possible values include: 'Purgeable', 'RecoverablePurgeable', 'Recoverable', 'RecoverableProtectedSubscription', 'CustomizedRecoverablePurgeable', 'CustomizedRecoverable', 'CustomizedRecoverableProtectedSubscription'|
+|enabled|boolean|Determines whether the object is enabled|
+|not_before|timestamp without time zone|Not before date in UTC|
+|expires|timestamp without time zone|Expiry date in UTC|
+|created|timestamp without time zone|Creation time in UTC|
+|updated|timestamp without time zone|Last updated time in UTC|
+|tags|jsonb|Application specific metadata in the form of key-value pairs|
+|content_type|text|Type of the secret value such as a password|
+|managed|boolean|True if the secret's lifetime is managed by key vault If this is a key backing a certificate, then managed will be true|

--- a/docs/tables/azure_keyvault_vaults.md
+++ b/docs/tables/azure_keyvault_vaults.md
@@ -1,0 +1,28 @@
+
+# Table: azure_keyvault_vaults
+Azure ketvault vault
+## Columns
+| Name        | Type           | Description  |
+| ------------- | ------------- | -----  |
+|subscription_id|text|Azure subscription id|
+|id|text|Fully qualified identifier of the key vault resource|
+|name|text|Name of the key vault resource|
+|type|text|Resource type of the key vault resource|
+|location|text|Azure location of the key vault resource|
+|tags|jsonb|Tags assigned to the key vault resource|
+|tenant_id|uuid|The Azure Active Directory tenant ID that should be used for authenticating requests to the key vault|
+|sku_family|text|SKU family name|
+|sku_name|text|SKU name to specify whether the key vault is a standard vault or a premium vault Possible values include: 'Standard', 'Premium'|
+|vault_uri|text|The URI of the vault for performing operations on keys and secrets|
+|enabled_for_deployment|boolean|Property to specify whether Azure Virtual Machines are permitted to retrieve certificates stored as secrets from the key vault|
+|enabled_for_disk_encryption|boolean|Property to specify whether Azure Disk Encryption is permitted to retrieve secrets from the vault and unwrap keys|
+|enabled_for_template_deployment|boolean|Property to specify whether Azure Resource Manager is permitted to retrieve secrets from the key vault|
+|enable_soft_delete|boolean|Property to specify whether the 'soft delete' functionality is enabled for this key vault If it's not set to any value(true or false) when creating new key vault, it will be set to true by default Once set to true, it cannot be reverted to false|
+|soft_delete_retention_in_days|integer|softDelete data retention days It accepts >=7 and <=90|
+|enable_rbac_authorization|boolean|Property that controls how data actions are authorized When true, the key vault will use Role Based Access Control (RBAC) for authorization of data actions, and the access policies specified in vault properties will be  ignored (warning: this is a preview feature) When false, the key vault will use the access policies specified in vault properties, and any policy stored on Azure Resource Manager will be ignored If null or not specified, the vault is created with the default value of false Note that management actions are always authorized with RBAC|
+|create_mode|text|The vault's create mode to indicate whether the vault need to be recovered or not Possible values include: 'CreateModeRecover', 'CreateModeDefault'|
+|enable_purge_protection|boolean|Property specifying whether protection against purge is enabled for this vault Setting this property to true activates protection against purge for this vault and its content - only the Key Vault service may initiate a hard, irrecoverable deletion The setting is effective only if soft delete is also enabled Enabling this functionality is irreversible - that is, the property does not accept false as its value|
+|network_acls_bypass|text|Tells what traffic can bypass network rules This can be 'AzureServices' or 'None'  If not specified the default is 'AzureServices' Possible values include: 'AzureServices', 'None'|
+|network_acls_default_action|text|The default action when no rule from ipRules and from virtualNetworkRules match This is only used after the bypass property has been evaluated Possible values include: 'Allow', 'Deny'|
+|network_acls_ip_rules|text[]|The list of IP address rules|
+|network_acls_virtual_network_rules|text[]|The list of virtual network rules|

--- a/resources/provider/provider.go
+++ b/resources/provider/provider.go
@@ -7,6 +7,7 @@ import (
 	"github.com/cloudquery/cq-provider-azure/resources/services/authorization"
 	"github.com/cloudquery/cq-provider-azure/resources/services/compute"
 	"github.com/cloudquery/cq-provider-azure/resources/services/container"
+	"github.com/cloudquery/cq-provider-azure/resources/services/keyvault"
 	"github.com/cloudquery/cq-provider-azure/resources/services/monitor"
 	"github.com/cloudquery/cq-provider-azure/resources/services/mysql"
 	"github.com/cloudquery/cq-provider-azure/resources/services/network"
@@ -41,7 +42,7 @@ func Provider() *provider.Provider {
 			"container.managed_clusters":     container.ContainerManagedClusters(),
 			// This resource is currently not working
 			// https://github.com/cloudquery/cq-provider-azure/issues/107
-			// "keyvault.vaults":      keyvault.KeyvaultVaults(),
+			"keyvault.vaults":      keyvault.KeyvaultVaults(),
 			"monitor.log_profiles": monitor.MonitorLogProfiles(),
 			// This resource is currently not working
 			// "monitor.diagnostic_settings":         monitor.MonitorDiagnosticSettings(),


### PR DESCRIPTION
(this resource requires a special permissions).

This resource still requires a documentation on what permission it needs and maybe some better error message and reference to docs on how to grant correct permissions if this data is needed. Related - https://github.com/cloudquery/cq-provider-azure/issues/107

I removed this resource completely but now enabled this back because the policy are using it. 