### PR TITLE
fix: Diagnostic types in ErrorClassifier

### DIFF
--- a/client/errors.go
+++ b/client/errors.go
@@ -25,15 +25,15 @@ func ErrorClassifier(meta schema.ClientMeta, resourceName string, err error) dia
 		switch detailedError.StatusCode {
 		case http.StatusNotFound:
 			return diag.Diagnostics{
-				RedactError(client.SubscriptionId, diag.NewBaseError(err, diag.RESOLVING, diag.WithSeverity(diag.IGNORE), diag.WithResourceName(resourceName), ParseSummaryMessage(client.SubscriptionId, err, detailedError), diag.WithDetails("%s", errorCodeDescriptions[detailedError.StatusCode]))),
+				RedactError(client.SubscriptionId, diag.NewBaseError(err, diag.RESOLVING, diag.WithType(diag.RESOLVING), diag.WithSeverity(diag.IGNORE), diag.WithResourceName(resourceName), ParseSummaryMessage(client.SubscriptionId, err, detailedError), diag.WithDetails("%s", errorCodeDescriptions[detailedError.StatusCode]))),
 			}
 		case http.StatusBadRequest:
 			return diag.Diagnostics{
-				RedactError(client.SubscriptionId, diag.NewBaseError(err, diag.RESOLVING, diag.WithSeverity(diag.WARNING), diag.WithResourceName(resourceName), ParseSummaryMessage(client.SubscriptionId, err, detailedError), diag.WithDetails("%s", errorCodeDescriptions[detailedError.StatusCode]))),
+				RedactError(client.SubscriptionId, diag.NewBaseError(err, diag.RESOLVING, diag.WithType(diag.RESOLVING), diag.WithSeverity(diag.WARNING), diag.WithResourceName(resourceName), ParseSummaryMessage(client.SubscriptionId, err, detailedError), diag.WithDetails("%s", errorCodeDescriptions[detailedError.StatusCode]))),
 			}
 		case http.StatusForbidden:
 			return diag.Diagnostics{
-				RedactError(client.SubscriptionId, diag.NewBaseError(err, diag.ACCESS, diag.WithSeverity(diag.WARNING), diag.WithResourceName(resourceName), ParseSummaryMessage(client.SubscriptionId, err, detailedError), diag.WithDetails("%s", errorCodeDescriptions[detailedError.StatusCode]))),
+				RedactError(client.SubscriptionId, diag.NewBaseError(err, diag.ACCESS, diag.WithType(diag.ACCESS), diag.WithSeverity(diag.WARNING), diag.WithResourceName(resourceName), ParseSummaryMessage(client.SubscriptionId, err, detailedError), diag.WithDetails("%s", errorCodeDescriptions[detailedError.StatusCode]))),
 			}
 		}
 	}


### PR DESCRIPTION
If the `err` is a `BaseError`, `NewBaseError(err, <TYPE>)` won't overwrite the type which results in errors having the wrong type.