### PR TITLE
fix: Fetch from default subscriptions for integration tests

### DIFF
--- a/resources/provider/integration_test.go
+++ b/resources/provider/integration_test.go
@@ -9,11 +9,5 @@ import (
 )
 
 func TestIntegration(t *testing.T) {
-	config := `
-		subscriptions = ["78f26f10-0e60-4293-8a7e-122584ccb40d"]
-	`
-	providertest.TestResource(t, providertest.ResourceTestCase{
-		Provider: Provider(),
-		Config:   config,
-	})
+	providertest.TestResource(t, providertest.ResourceTestCase{Provider: Provider()})
 }


### PR DESCRIPTION
This fixes an issue where it was impossible to run azure integration tests locally,
because cloudquery's integration-environment's subscription id was hardcoded.