### PR TITLE
fix: Clasify Subscription Not Registered

### DIFF
--- a/client/errors.go
+++ b/client/errors.go
@@ -41,6 +41,7 @@ func classifyError(err error, fallbackType diag.Type, subId string, opts ...diag
 					RedactError(subId, diag.NewBaseError(err, diag.ACCESS, append(opts, diag.WithType(diag.ACCESS), diag.WithSeverity(diag.WARNING), ParseSummaryMessage(subId, err, detailedError), diag.WithDetails("%s", errorCodeDescriptions[detailedError.StatusCode]))...)),
 				}
 			case "SubscriptionNotRegistered":
+			case "Subscription Not Registered":
 				return diag.Diagnostics{
 					RedactError(subId, diag.NewBaseError(err, diag.ACCESS, append(opts, diag.WithType(diag.ACCESS), diag.WithSeverity(diag.WARNING), ParseSummaryMessage(subId, err, detailedError), diag.WithDetails("%s", errorCodeDescriptions[detailedError.StatusCode]))...)),
 				}


### PR DESCRIPTION
🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉

#### Summary

Classifies
```
Error: autorest/azure: Service returned an error. Status=401 Code="Subscription Not Registered" Message="Please register to Microsoft.Security in order to view your security status"
```

Follow up to https://github.com/cloudquery/cq-provider-azure/pull/284. I got a similar error code, so adding it.

---

Use the following steps to ensure your PR is ready to be reviewed

- [x] Read the [contribution guidelines](../blob/main/CONTRIBUTING.md) 🧑‍🎓
- [x] Run `go fmt` to format your code 🖊
- [x] Lint your changes via `golangci-lint run --new-from-rev main` 🚨 (install golangci-lint [here](https://golangci-lint.run/usage/install/#local-installation))
- [x] Update or add tests. Learn more about testing [here](https://docs.cloudquery.io/docs/developers/sdk/testing) 🧪
- [x] Update the docs by running `go run ./docs/docs.go` and committing the changes 📃
- [x] If adding a new resource, add [relevant Terraform files](../terraform) in a separate PR 📂
- [x] Ensure the status checks below are successful ✅
