### PR TITLE
feat: Set location to 'unavailable' rather than null in view

### DIFF
--- a/resources/provider/views_test.go
+++ b/resources/provider/views_test.go
@@ -1,0 +1,16 @@
+package provider
+
+import (
+	_ "embed"
+	"testing"
+
+	"github.com/cloudquery/cq-provider-azure/views"
+	providertest "github.com/cloudquery/cq-provider-sdk/provider/testing"
+)
+
+func TestViews(t *testing.T) {
+	providertest.HelperTestView(t, providertest.ViewTestCase{
+		Provider: Provider(),
+		SQLView:  views.ResourceView,
+	})
+}

--- a/views/resource.sql
+++ b/views/resource.sql
@@ -23,7 +23,7 @@ LOOP
         FROM %s', tbl,
             CASE WHEN EXISTS (SELECT 1 FROM information_schema.columns WHERE column_name='name' AND table_name=tbl) THEN 'name' ELSE 'NULL' END,
             CASE WHEN EXISTS (SELECT 1 FROM information_schema.columns WHERE column_name='kind' AND table_name=tbl) THEN 'kind' ELSE 'NULL' END,
-            CASE WHEN EXISTS (SELECT 1 FROM information_schema.columns WHERE column_name='location' AND table_name=tbl) THEN 'location' ELSE 'NULL' END,
+            CASE WHEN EXISTS (SELECT 1 FROM information_schema.columns WHERE column_name='location' AND table_name=tbl) THEN 'location' ELSE E'\'unavailable\'' END,
             CASE WHEN EXISTS (SELECT 1 FROM information_schema.columns WHERE column_name='fetch_date' AND table_name=tbl) THEN 'fetch_date' ELSE 'NULL::timestamp' END,
     tbl);
 


### PR DESCRIPTION
Some tables do not have a location column. In order to work nicely with Grafana, we should explicitly indicate this rather than leaving such location entries null. This relates to https://github.com/cloudquery/dashboards/pull/22

This change also adds a test for views that does a basic check to see that it can be loaded without errors.