### PR TITLE
fix: Move mock generation to separate files

### DIFF
--- a/client/services/ad.go
+++ b/client/services/ad.go
@@ -1,3 +1,7 @@
+//go:generate mockgen -destination=./mocks/ad_applications.go -package=mocks . ADApplicationsClient
+//go:generate mockgen -destination=./mocks/ad_groups.go -package=mocks . ADGroupsClient
+//go:generate mockgen -destination=./mocks/ad_service_principals.go -package=mocks . ADServicePrinicpals
+//go:generate mockgen -destination=./mocks/ad_users.go -package=mocks . ADUsersClient
 package services
 
 import (

--- a/client/services/authorization.go
+++ b/client/services/authorization.go
@@ -1,3 +1,4 @@
+//go:generate mockgen -destination=./mocks/authorization.go -package=mocks . RoleAssignmentsClient,RoleDefinitionsClient
 package services
 
 import (

--- a/client/services/batch.go
+++ b/client/services/batch.go
@@ -1,3 +1,4 @@
+//go:generate mockgen -destination=./mocks/batch.go -package=mocks . BatchAccountClient
 package services
 
 import (

--- a/client/services/containerservice.go
+++ b/client/services/containerservice.go
@@ -1,3 +1,4 @@
+//go:generate mockgen -destination=./mocks/containerservice.go -package=mocks . ManagedClustersClient
 package services
 
 import (

--- a/client/services/cosmosdb.go
+++ b/client/services/cosmosdb.go
@@ -1,3 +1,4 @@
+//go:generate mockgen -destination=./mocks/cosmosdb.go -package=mocks . CosmosDBAccountClient,CosmosDBSQLClient,CosmosDBMongoDBClient
 package services
 
 import (

--- a/client/services/eventhub.go
+++ b/client/services/eventhub.go
@@ -1,3 +1,4 @@
+//go:generate mockgen -destination=./mocks/eventhub.go -package=mocks . EventHubClient
 package services
 
 import (

--- a/client/services/iothub.go
+++ b/client/services/iothub.go
@@ -1,3 +1,4 @@
+//go:generate mockgen -destination=./mocks/iothub.go -package=mocks . IotHubClient
 package services
 
 import (

--- a/client/services/keyvault.go
+++ b/client/services/keyvault.go
@@ -1,3 +1,4 @@
+//go:generate mockgen -destination=./mocks/keyvault.go -package=mocks . KeyVault71Client,VaultClient,KeyVaultManagedHSMClient,KeysClient
 package services
 
 import (

--- a/client/services/logic.go
+++ b/client/services/logic.go
@@ -1,3 +1,4 @@
+//go:generate mockgen -destination=./mocks/logic.go -package=mocks . MonitorDiagnosticSettingsClient,WorkflowsClient
 package services
 
 import (

--- a/client/services/mariadb.go
+++ b/client/services/mariadb.go
@@ -1,3 +1,4 @@
+//go:generate mockgen -destination=./mocks/mariadb.go -package=mocks . MariaDBConfigurationsClient,MariaDBServersClient
 package services
 
 import (

--- a/client/services/monitor.go
+++ b/client/services/monitor.go
@@ -1,3 +1,4 @@
+//go:generate mockgen -destination=./mocks/monitor.go -package=mocks . ActivityLogAlertsClient,LogProfilesClient,DiagnosticSettingsClient,ActivityLogClient
 package services
 
 import (

--- a/client/services/mysql.go
+++ b/client/services/mysql.go
@@ -1,3 +1,4 @@
+//go:generate mockgen -destination=./mocks/my_sql.go -package=mocks . MySQLServerClient,MySQLConfigurationClient
 package services
 
 import (

--- a/client/services/networks.go
+++ b/client/services/networks.go
@@ -1,3 +1,4 @@
+//go:generate mockgen -destination=./mocks/network.go -package=mocks . ExpressRouteCircuitsClient,ExpressRouteGatewaysClient,ExpressRoutePortsClient,InterfacesClient,PublicIPAddressesClient,RouteFiltersClient,RouteTablesClient,SecurityGroupsClient,VirtualNetworkGatewaysClient,VirtualNetworksClient,WatchersClient
 package services
 
 import (

--- a/client/services/postgresql.go
+++ b/client/services/postgresql.go
@@ -1,3 +1,4 @@
+//go:generate mockgen -destination=./mocks/postgresql.go -package=mocks . PostgresqlConfigurationClient,PostgresqlServerClient,PostgresqlFirewallRuleClient
 package services
 
 import (

--- a/client/services/redis.go
+++ b/client/services/redis.go
@@ -1,3 +1,4 @@
+//go:generate mockgen -destination=./mocks/redis.go -package=mocks . RedisClient
 package services
 
 import (

--- a/client/services/resources.go
+++ b/client/services/resources.go
@@ -1,3 +1,4 @@
+//go:generate mockgen -destination=./mocks/resources.go -package=mocks . ResClient,GroupsClient,AssignmentsClient,LinksClient
 package services
 
 import (

--- a/client/services/search.go
+++ b/client/services/search.go
@@ -1,3 +1,4 @@
+//go:generate mockgen -destination=./mocks/search.go -package=mocks . SearchServiceClient
 package services
 
 import (

--- a/client/services/security.go
+++ b/client/services/security.go
@@ -1,3 +1,4 @@
+//go:generate mockgen -destination=./mocks/security.go -package=mocks . SecurityAutoProvisioningSettingsClient,SecurityContactsClient,SecurityPricingsClient,SecuritySettingsClient,JitNetworkAccessPoliciesClient,AssessmentsClient
 package services
 
 import (

--- a/client/services/servicebus.go
+++ b/client/services/servicebus.go
@@ -1,3 +1,4 @@
+//go:generate mockgen -destination=./mocks/servicebus.go -package=mocks . NamespacesClient
 package services
 
 import (

--- a/client/services/services.go
+++ b/client/services/services.go
@@ -1,29 +1,3 @@
-//go:generate mockgen -destination=./mocks/ad_applications.go -package=mocks . ADApplicationsClient
-//go:generate mockgen -destination=./mocks/ad_groups.go -package=mocks . ADGroupsClient
-//go:generate mockgen -destination=./mocks/ad_service_principals.go -package=mocks . ADServicePrinicpals
-//go:generate mockgen -destination=./mocks/ad_users.go -package=mocks . ADUsersClient
-//go:generate mockgen -destination=./mocks/authorization.go -package=mocks . RoleAssignmentsClient,RoleDefinitionsClient
-//go:generate mockgen -destination=./mocks/containerservice.go -package=mocks . ManagedClustersClient
-//go:generate mockgen -destination=./mocks/eventhub.go -package=mocks . EventHubClient
-//go:generate mockgen -destination=./mocks/keyvault.go -package=mocks . KeyVault71Client,VaultClient,KeyVaultManagedHSMClient,KeysClient
-//go:generate mockgen -destination=./mocks/monitor.go -package=mocks . ActivityLogAlertsClient,LogProfilesClient,DiagnosticSettingsClient,ActivityLogClient
-//go:generate mockgen -destination=./mocks/logic.go -package=mocks . MonitorDiagnosticSettingsClient,WorkflowsClient
-//go:generate mockgen -destination=./mocks/mariadb.go -package=mocks . MariaDBConfigurationsClient,MariaDBServersClient
-//go:generate mockgen -destination=./mocks/my_sql.go -package=mocks . MySQLServerClient,MySQLConfigurationClient
-//go:generate mockgen -destination=./mocks/network.go -package=mocks . ExpressRouteCircuitsClient,ExpressRouteGatewaysClient,ExpressRoutePortsClient,InterfacesClient,PublicIPAddressesClient,RouteFiltersClient,RouteTablesClient,SecurityGroupsClient,VirtualNetworkGatewaysClient,VirtualNetworksClient,WatchersClient
-//go:generate mockgen -destination=./mocks/postgresql.go -package=mocks . PostgresqlConfigurationClient,PostgresqlServerClient,PostgresqlFirewallRuleClient
-//go:generate mockgen -destination=./mocks/redis.go -package=mocks . RedisClient
-//go:generate mockgen -destination=./mocks/resources.go -package=mocks . ResClient,GroupsClient,AssignmentsClient,LinksClient
-//go:generate mockgen -destination=./mocks/servicebus.go -package=mocks . NamespacesClient
-//go:generate mockgen -destination=./mocks/security.go -package=mocks . SecurityAutoProvisioningSettingsClient,SecurityContactsClient,SecurityPricingsClient,SecuritySettingsClient,JitNetworkAccessPoliciesClient,AssessmentsClient
-//go:generate mockgen -destination=./mocks/streamanalytics.go -package=mocks . JobsClient
-//go:generate mockgen -destination=./mocks/storage.go -package=mocks . StorageAccountClient,StorageBlobServicePropertiesClient,StorageBlobServicesClient,StorageContainerClient,StorageQueueServicePropertiesClient
-//go:generate mockgen -destination=./mocks/subscriptions.go -package=mocks . SubscriptionGetter
-//go:generate mockgen -destination=./mocks/web.go -package=mocks . AppsClient
-//go:generate mockgen -destination=./mocks/cosmosdb.go -package=mocks . CosmosDBAccountClient,CosmosDBSQLClient,CosmosDBMongoDBClient
-//go:generate mockgen -destination=./mocks/iothub.go -package=mocks . IotHubClient
-//go:generate mockgen -destination=./mocks/batch.go -package=mocks . BatchAccountClient
-//go:generate mockgen -destination=./mocks/search.go -package=mocks . SearchServiceClient
 package services
 
 import "github.com/Azure/go-autorest/autorest"

--- a/client/services/storage.go
+++ b/client/services/storage.go
@@ -1,3 +1,4 @@
+//go:generate mockgen -destination=./mocks/storage.go -package=mocks . StorageAccountClient,StorageBlobServicePropertiesClient,StorageBlobServicesClient,StorageContainerClient,StorageQueueServicePropertiesClient
 package services
 
 import (

--- a/client/services/streamanalytics.go
+++ b/client/services/streamanalytics.go
@@ -1,3 +1,4 @@
+//go:generate mockgen -destination=./mocks/streamanalytics.go -package=mocks . JobsClient
 package services
 
 import (

--- a/client/services/web.go
+++ b/client/services/web.go
@@ -1,3 +1,4 @@
+//go:generate mockgen -destination=./mocks/web.go -package=mocks . AppsClient
 package services
 
 import (


### PR DESCRIPTION
Before this change, there was a mix between build strings in `services.go` and in the separate service files. This ambiguity also seems to have resulted in a bug (https://github.com/cloudquery/cq-provider-azure/issues/408), which this change fixes. 

I tested it by deleting all the files in the mocks directory and regenerating them using `make generate-mocks`, which resulted in no changes according to git. 

Closes https://github.com/cloudquery/cq-provider-azure/issues/408