### PR TITLE
chore: Upgrade to go 1.18

### DIFF
--- a/.github/workflows/lint_doc.yml
+++ b/.github/workflows/lint_doc.yml
@@ -24,7 +24,7 @@ jobs:
         if: steps.changes.outputs.src == 'true' || github.event_name != 'pull_request'
         uses: actions/setup-go@v3
         with:
-          go-version: ^1.17
+          go-version: ^1.18
       - uses: actions/cache@v3
         if: steps.changes.outputs.src == 'true' || github.event_name != 'pull_request'
         with:

--- a/.github/workflows/lint_golang.yml
+++ b/.github/workflows/lint_golang.yml
@@ -24,7 +24,7 @@ jobs:
       - uses: actions/setup-go@v3
         if: steps.changes.outputs.src == 'true' || github.event_name != 'pull_request'
         with:
-          go-version: 1.17
+          go-version: 1.18
 
       - name: golangci-lint
         if: steps.changes.outputs.src == 'true' || github.event_name != 'pull_request'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v3
         with:
-          go-version: 1.17
+          go-version: 1.18
       - name: Run GoReleaser Dry-Run
         uses: goreleaser/goreleaser-action@v3
         with:

--- a/.github/workflows/terraform_apply.yml
+++ b/.github/workflows/terraform_apply.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Set up Go 1.x
         uses: actions/setup-go@v3
         with:
-          go-version: ^1.17
+          go-version: ^1.18
 
       - name: Checkout
         uses: actions/checkout@v3

--- a/.github/workflows/terraform_plan.yml
+++ b/.github/workflows/terraform_plan.yml
@@ -70,7 +70,7 @@ jobs:
         if: steps.changes.outputs.src == 'true' || github.event_name != 'pull_request_target'
         uses: actions/setup-go@v3
         with:
-          go-version: ^1.17
+          go-version: ^1.18
 
 
       - name: Setup Terraform

--- a/.github/workflows/test_integration.yml
+++ b/.github/workflows/test_integration.yml
@@ -64,7 +64,7 @@ jobs:
     strategy:
       matrix:
         dbversion: [ "postgres:10" ]
-        go: [ "1.17" ]
+        go: [ "1.18" ]
         platform: [ ubuntu-latest ] # can not run in macOS and windowsOS
     runs-on: ${{ matrix.platform }}
     services:

--- a/.github/workflows/test_policy.yml
+++ b/.github/workflows/test_policy.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       matrix:
         dbversion: [ "postgres:10" ]
-        go: [ "1.17" ]
+        go: [ "1.18" ]
         platform: [ ubuntu-latest ] # can not run in macOS and widnowsOS
     runs-on: ${{ matrix.platform }}
     services:

--- a/.github/workflows/test_unit.yml
+++ b/.github/workflows/test_unit.yml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       matrix:
         dbversion: ["postgres:10"]
-        go: ["1.17"]
+        go: ["1.18"]
         platform: [ubuntu-latest] # can not run in macOS and windowsOS
     runs-on: ${{ matrix.platform }}
     services:

--- a/.github/workflows/validate_release.yml
+++ b/.github/workflows/validate_release.yml
@@ -20,7 +20,7 @@ jobs:
         if: startsWith(github.head_ref, 'release')
         uses: actions/setup-go@v3
         with:
-          go-version: 1.17
+          go-version: 1.18
       - name: Run GoReleaser Dry-Run
         if: startsWith(github.head_ref, 'release')
         uses: goreleaser/goreleaser-action@v3

--- a/docs/contributing/development_environment.md
+++ b/docs/contributing/development_environment.md
@@ -1,7 +1,7 @@
 # Development Environment Setup
 
 ## Requirements
- * [Go](https://go.dev/doc/install) 1.17+ (to build the provider)
+ * [Go](https://go.dev/doc/install) 1.18+ (to build the provider)
  * [Terraform](https://www.terraform.io/downloads) (Needed only to run integration tests)
 
 ## Quick Start

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/cloudquery/cq-provider-azure
 
-go 1.17
+go 1.18
 
 require (
 	github.com/Azure/azure-sdk-for-go v61.6.0+incompatible


### PR DESCRIPTION
Upgrade to Go 1.18, as this is a requirement for using the new Azure armsubscription SDKs: https://pkg.go.dev/github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armsubscriptions#section-readme.

It looks like golangci-lint automatically disables some linters that are not yet ready for Go 1.18, which results in some warnings but no errors.