### PR TITLE
fix(tests): Remove terraform for Azure ExpressRoute port

### DIFF
--- a/resources/services/network/express_route_ports.go
+++ b/resources/services/network/express_route_ports.go
@@ -11,12 +11,13 @@ import (
 
 func NetworkExpressRoutePorts() *schema.Table {
 	return &schema.Table{
-		Name:         "azure_network_express_route_ports",
-		Description:  "Azure Network Express Route Ports",
-		Resolver:     fetchNetworkExpressRoutePorts,
-		Multiplex:    client.SubscriptionMultiplex,
-		DeleteFilter: client.DeleteSubscriptionFilter,
-		Options:      schema.TableCreationOptions{PrimaryKeys: []string{"subscription_id", "id"}},
+		Name:          "azure_network_express_route_ports",
+		Description:   "Azure Network Express Route Ports",
+		Resolver:      fetchNetworkExpressRoutePorts,
+		Multiplex:     client.SubscriptionMultiplex,
+		DeleteFilter:  client.DeleteSubscriptionFilter,
+		Options:       schema.TableCreationOptions{PrimaryKeys: []string{"subscription_id", "id"}},
+		IgnoreInTests: true,
 		Columns: []schema.Column{
 			{
 				Name:        "subscription_id",

--- a/terraform/network/modules/test/network.tf
+++ b/terraform/network/modules/test/network.tf
@@ -3,15 +3,6 @@ resource "azurerm_resource_group" "network" {
   location = "East US"
 }
 
-resource "azurerm_express_route_port" "er_port" {
-  name                = "${var.prefix}-er-port"
-  resource_group_name = azurerm_resource_group.network.name
-  location            = azurerm_resource_group.network.location
-  peering_location    = "Equinix-Amsterdam-AM5"
-  bandwidth_in_gbps   = 10
-  encapsulation       = "Dot1Q"
-}
-
 resource "azurerm_express_route_circuit" "er_circuit" {
   name                  = "${var.prefix}-circuit"
   resource_group_name   = azurerm_resource_group.network.name


### PR DESCRIPTION
This was costing ~6k per month, and the terraform resource doesn't allow us to use the lowest bandwidth setting of 50mbps, since it has to be specified in whole-number gbps

