### PR TITLE
chore(build): Add support for drift detection of generated code

### DIFF
--- a/.github/workflows/check_generated_code_drift.yml
+++ b/.github/workflows/check_generated_code_drift.yml
@@ -1,0 +1,61 @@
+name: check_generated_code_drift
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'resources/services/**/*'
+  pull_request:
+    branches:
+      - main
+    paths:
+      - 'resources/services/**/*'
+jobs:
+  check_generated_code_drift:
+    name: Check Generated Code for Drift
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - uses: dorny/paths-filter@v2
+        id: changes
+        with:
+          filters: |
+            src:
+              - 'resources/services/**/*'
+      - name: Set up Go 1.x
+        if: steps.changes.outputs.src == 'true' || github.event_name != 'pull_request'
+        uses: actions/setup-go@v3
+        with:
+          go-version: ^1.18
+      - name: Install tools
+        if: steps.changes.outputs.src == 'true' || github.event_name != 'pull_request'
+        run: |
+          make install-tools
+      - uses: actions/cache@v3
+        if: steps.changes.outputs.src == 'true' || github.event_name != 'pull_request'
+        with:
+          # In order:
+          # * Module download cache
+          # * Build cache (Linux)
+          # * Build cache (Mac)
+          # * Build cache (Windows)
+          path: |
+            ~/go/pkg/mod
+            ~/.cache/go-build
+            ~/Library/Caches/go-build
+            ~\AppData\Local\go-build
+          key: ${{ runner.os }}-go-${{ matrix.go }}-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go-${{ matrix.go }}-
+      - name: Run go generate on changed service directories
+        if: steps.changes.outputs.src == 'true' || github.event_name != 'pull_request'
+        run: |
+          ./scripts/regenerate-changed-directories.sh
+      - name: Fail if any files are changed
+        if: steps.changes.outputs.src == 'true' || github.event_name != 'pull_request'
+        run: |
+          echo "List of files changed after running go generate:"
+          git status -s ./resources/services
+          test "$(git status -s ./resources/services | wc -l)" -eq 0

--- a/.github/workflows/check_generated_code_drift.yml
+++ b/.github/workflows/check_generated_code_drift.yml
@@ -3,13 +3,9 @@ on:
   push:
     branches:
       - main
-    paths:
-      - 'resources/services/**/*'
   pull_request:
     branches:
       - main
-    paths:
-      - 'resources/services/**/*'
 jobs:
   check_generated_code_drift:
     name: Check Generated Code for Drift
@@ -49,6 +45,10 @@ jobs:
           key: ${{ runner.os }}-go-${{ matrix.go }}-${{ hashFiles('**/go.sum') }}
           restore-keys: |
             ${{ runner.os }}-go-${{ matrix.go }}-
+      - name: Fail if new cq-gen config file is missing //check-for-changes
+        if: steps.changes.outputs.src == 'true' || github.event_name != 'pull_request'
+        run: |
+          ./scripts/check-new-files-have-check-for-changes-flag.sh
       - name: Run go generate on changed service directories
         if: steps.changes.outputs.src == 'true' || github.event_name != 'pull_request'
         run: |

--- a/scripts/check-new-files-have-check-for-changes-flag.sh
+++ b/scripts/check-new-files-have-check-for-changes-flag.sh
@@ -1,0 +1,17 @@
+set -x
+set -e
+
+for d in ./resources/services/*/ ; do
+  # check if there is a new cq-gen .hcl config file
+  if git diff --name-status origin/main HEAD -- $d | grep -q '^A.*\.hcl$'; then
+    # .hcl file was newly added
+    if grep -q '//check-for-changes' "$d"*.hcl; then
+      echo "cq-gen config files in $d are OK";
+    else
+      echo "//check-for-changes must be present in all new cq-gen config files";
+      exit 1;
+    fi;
+  else
+    echo "No new cq-gen config files found in $d"
+  fi;
+done

--- a/scripts/regenerate-changed-directories.sh
+++ b/scripts/regenerate-changed-directories.sh
@@ -1,0 +1,15 @@
+set -x
+set -e
+
+for d in ./resources/services/*/ ; do
+  # check whether directory changed in this branch
+  if git diff --quiet origin/main HEAD -- $d; then
+    echo "no changes in $d";
+    continue;
+  fi
+
+  # regenerate if //check-for-changes is present in an .hcl file
+  if grep -s -q '//check-for-changes' "$d"*.hcl; then
+   (cd $d && go generate);
+  fi
+done


### PR DESCRIPTION
This adds a new workflow that checks that generated code remains the same when go generate is run again. It currently needs to be specifically enabled by adding //check-for-changes to the top of the generator .hcl file.
